### PR TITLE
4.9 Variable for newsletter reader view link

### DIFF
--- a/src/Resources/contao/classes/Newsletter.php
+++ b/src/Resources/contao/classes/Newsletter.php
@@ -339,6 +339,9 @@ class Newsletter extends \Backend
 			}
 		}
 
+		// Newsletters with an unsubscribe header are less likely to be blocked (see #2174)
+		$objEmail->addHeader('List-Unsubscribe', '<mailto:' . $objNewsletter->sender . '?subject=' . rawurlencode($GLOBALS['TL_LANG']['MSC']['unsubscribe']) . '>');
+
 		return $objEmail;
 	}
 

--- a/src/Resources/contao/languages/cs/tl_newsletter.xlf
+++ b/src/Resources/contao/languages/cs/tl_newsletter.xlf
@@ -202,6 +202,7 @@
       </trans-unit>
       <trans-unit id="tl_newsletter.new.0">
         <source>New</source>
+        <target>Nové</target>
       </trans-unit>
       <trans-unit id="tl_newsletter.new.1">
         <source>Create a new newsletter</source>

--- a/src/Resources/contao/languages/cs/tl_newsletter_channel.xlf
+++ b/src/Resources/contao/languages/cs/tl_newsletter_channel.xlf
@@ -62,6 +62,7 @@
       </trans-unit>
       <trans-unit id="tl_newsletter_channel.new.0">
         <source>New</source>
+        <target>Nové</target>
       </trans-unit>
       <trans-unit id="tl_newsletter_channel.new.1">
         <source>Create a new channel</source>

--- a/src/Resources/contao/languages/cs/tl_newsletter_recipients.xlf
+++ b/src/Resources/contao/languages/cs/tl_newsletter_recipients.xlf
@@ -71,6 +71,7 @@
       </trans-unit>
       <trans-unit id="tl_newsletter_recipients.new.0">
         <source>New</source>
+        <target>Nové</target>
       </trans-unit>
       <trans-unit id="tl_newsletter_recipients.new.1">
         <source>Create a new recipient</source>

--- a/src/Resources/contao/languages/fa/tl_module.xlf
+++ b/src/Resources/contao/languages/fa/tl_module.xlf
@@ -55,6 +55,7 @@
       </trans-unit>
       <trans-unit id="tl_module.nl_template.1">
         <source>Here you can select a newsletter template.</source>
+        <target>اینجا می‌توانید قالب خبرنامه را انتخاب کنید.</target>
       </trans-unit>
       <trans-unit id="tl_module.text_legend">
         <source>Custom text</source>

--- a/src/Resources/contao/languages/fa/tl_newsletter.xlf
+++ b/src/Resources/contao/languages/fa/tl_newsletter.xlf
@@ -55,6 +55,7 @@
       </trans-unit>
       <trans-unit id="tl_newsletter.template.1">
         <source>Here you can override the e-mail template of the channel.</source>
+        <target>اینجا می‌توانید قابل ایمیل کانال را رونویسی کنید.</target>
       </trans-unit>
       <trans-unit id="tl_newsletter.sendText.0">
         <source>Send as plain text</source>

--- a/src/Resources/contao/languages/fa/tl_newsletter_channel.xlf
+++ b/src/Resources/contao/languages/fa/tl_newsletter_channel.xlf
@@ -23,6 +23,7 @@
       </trans-unit>
       <trans-unit id="tl_newsletter_channel.template.1">
         <source>Here you can select an e-mail template.</source>
+        <target>اینجا می‌توانید قالب ایمیل را انتخاب کنید.</target>
       </trans-unit>
       <trans-unit id="tl_newsletter_channel.sender.0">
         <source>Sender e-mail address</source>

--- a/src/Resources/contao/languages/it/tl_module.xlf
+++ b/src/Resources/contao/languages/it/tl_module.xlf
@@ -55,6 +55,7 @@
       </trans-unit>
       <trans-unit id="tl_module.nl_template.1">
         <source>Here you can select a newsletter template.</source>
+        <target>Qui puoi selezionare il template della newsletter</target>
       </trans-unit>
       <trans-unit id="tl_module.text_legend">
         <source>Custom text</source>

--- a/src/Resources/contao/languages/it/tl_newsletter.xlf
+++ b/src/Resources/contao/languages/it/tl_newsletter.xlf
@@ -55,6 +55,7 @@
       </trans-unit>
       <trans-unit id="tl_newsletter.template.1">
         <source>Here you can override the e-mail template of the channel.</source>
+        <target>Qui è possibile sovrascrivere il template di default dell'email in questo canale.</target>
       </trans-unit>
       <trans-unit id="tl_newsletter.sendText.0">
         <source>Send as plain text</source>

--- a/src/Resources/contao/languages/it/tl_newsletter_channel.xlf
+++ b/src/Resources/contao/languages/it/tl_newsletter_channel.xlf
@@ -23,6 +23,7 @@
       </trans-unit>
       <trans-unit id="tl_newsletter_channel.template.1">
         <source>Here you can select an e-mail template.</source>
+        <target>Seleziona una template per l'email.</target>
       </trans-unit>
       <trans-unit id="tl_newsletter_channel.sender.0">
         <source>Sender e-mail address</source>

--- a/src/Resources/contao/languages/it/tl_newsletter_recipients.xlf
+++ b/src/Resources/contao/languages/it/tl_newsletter_recipients.xlf
@@ -75,6 +75,7 @@
       </trans-unit>
       <trans-unit id="tl_newsletter_recipients.new.1">
         <source>Create a new recipient</source>
+        <target>Crea un nuovo destinatario</target>
       </trans-unit>
       <trans-unit id="tl_newsletter_recipients.show">
         <source>Show the details of recipient ID %s</source>

--- a/src/Resources/contao/languages/pl/tl_module.xlf
+++ b/src/Resources/contao/languages/pl/tl_module.xlf
@@ -55,6 +55,7 @@
       </trans-unit>
       <trans-unit id="tl_module.nl_template.1">
         <source>Here you can select a newsletter template.</source>
+        <target>Tutaj możesz wybrać szablon newslettera.</target>
       </trans-unit>
       <trans-unit id="tl_module.text_legend">
         <source>Custom text</source>

--- a/src/Resources/contao/languages/pl/tl_newsletter.xlf
+++ b/src/Resources/contao/languages/pl/tl_newsletter.xlf
@@ -55,6 +55,7 @@
       </trans-unit>
       <trans-unit id="tl_newsletter.template.1">
         <source>Here you can override the e-mail template of the channel.</source>
+        <target>Tutaj możesz nadpisać szablon e-maila kanału.</target>
       </trans-unit>
       <trans-unit id="tl_newsletter.sendText.0">
         <source>Send as plain text</source>

--- a/src/Resources/contao/languages/pl/tl_newsletter_channel.xlf
+++ b/src/Resources/contao/languages/pl/tl_newsletter_channel.xlf
@@ -23,6 +23,7 @@
       </trans-unit>
       <trans-unit id="tl_newsletter_channel.template.1">
         <source>Here you can select an e-mail template.</source>
+        <target>Tutaj możesz wybrać szablon e-maila.</target>
       </trans-unit>
       <trans-unit id="tl_newsletter_channel.sender.0">
         <source>Sender e-mail address</source>

--- a/src/Resources/contao/modules/ModuleNewsletterList.php
+++ b/src/Resources/contao/modules/ModuleNewsletterList.php
@@ -34,7 +34,9 @@ class ModuleNewsletterList extends Module
 	 */
 	public function generate()
 	{
-		if (TL_MODE == 'BE')
+		$request = System::getContainer()->get('request_stack')->getCurrentRequest();
+
+		if ($request && System::getContainer()->get('contao.routing.scope_matcher')->isBackendRequest($request))
 		{
 			$objTemplate = new BackendTemplate('be_wildcard');
 			$objTemplate->wildcard = '### ' . Utf8::strtoupper($GLOBALS['TL_LANG']['FMD']['newsletterlist'][0]) . ' ###';

--- a/src/Resources/contao/modules/ModuleNewsletterReader.php
+++ b/src/Resources/contao/modules/ModuleNewsletterReader.php
@@ -35,7 +35,9 @@ class ModuleNewsletterReader extends Module
 	 */
 	public function generate()
 	{
-		if (TL_MODE == 'BE')
+		$request = System::getContainer()->get('request_stack')->getCurrentRequest();
+
+		if ($request && System::getContainer()->get('contao.routing.scope_matcher')->isBackendRequest($request))
 		{
 			$objTemplate = new BackendTemplate('be_wildcard');
 			$objTemplate->wildcard = '### ' . Utf8::strtoupper($GLOBALS['TL_LANG']['FMD']['newsletterreader'][0]) . ' ###';

--- a/src/Resources/contao/modules/ModuleSubscribe.php
+++ b/src/Resources/contao/modules/ModuleSubscribe.php
@@ -39,7 +39,9 @@ class ModuleSubscribe extends Module
 	 */
 	public function generate()
 	{
-		if (TL_MODE == 'BE')
+		$request = System::getContainer()->get('request_stack')->getCurrentRequest();
+
+		if ($request && System::getContainer()->get('contao.routing.scope_matcher')->isBackendRequest($request))
 		{
 			$objTemplate = new BackendTemplate('be_wildcard');
 			$objTemplate->wildcard = '### ' . Utf8::strtoupper($GLOBALS['TL_LANG']['FMD']['subscribe'][0]) . ' ###';

--- a/src/Resources/contao/modules/ModuleUnsubscribe.php
+++ b/src/Resources/contao/modules/ModuleUnsubscribe.php
@@ -37,7 +37,9 @@ class ModuleUnsubscribe extends Module
 	 */
 	public function generate()
 	{
-		if (TL_MODE == 'BE')
+		$request = System::getContainer()->get('request_stack')->getCurrentRequest();
+
+		if ($request && System::getContainer()->get('contao.routing.scope_matcher')->isBackendRequest($request))
 		{
 			$objTemplate = new BackendTemplate('be_wildcard');
 			$objTemplate->wildcard = '### ' . Utf8::strtoupper($GLOBALS['TL_LANG']['FMD']['unsubscribe'][0]) . ' ###';


### PR DESCRIPTION
Hi,

can we get a variable for "view at website" link in a newsletter? Actually there is no such variable. You have to build an almost static link to archive this.

`<?= $this->replaceInsertTags( '{{env::url}}/' ); ?>intern/newsletter/<?= $this->alias ?>.html`

Greetings Frank